### PR TITLE
PR: Feat(Services): Add automated meeting date badges and Whakatane Group Info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -134,8 +134,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
       "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.7.6",
@@ -497,8 +496,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260306.1.tgz",
       "integrity": "sha512-1gtiB0nm0Uji6VKHprvL1ZyFtdHZSR907lU2fbBioMurJAF4tQPoafJFJp4oeViUiMVUEqkp0Eh0dcbcKoHoow==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2994,7 +2992,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3018,7 +3015,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3349,7 +3345,6 @@
       "integrity": "sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.6",
@@ -4870,7 +4865,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8578,7 +8572,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8595,7 +8588,6 @@
       "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.9.1",
         "prettier": "^3.0.0",
@@ -9073,7 +9065,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10188,7 +10179,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10269,7 +10259,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -11205,7 +11194,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -11695,7 +11683,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -12571,7 +12558,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -214,36 +214,136 @@ import '../styles/services.css';
 
       <div class="service-content">
         <p class="service-description">
-          Lorem ipsum dolor sit amet consectetur adipiscing elit. Dolor amet
-          consectetur adipiscing elit quisque faucibus.
+          Our support groups provide a safe, welcoming space for transgender and
+          gender-diverse people to connect, share experiences, and support one
+          another. All groups are free to attend.
         </p>
 
+        <!--Tauranga Groups -->
+        <div class="group-location-section">
+          <h3 class="group-location-heading">
+            <i class="fa-solid fa-location-dot"></i>
+            Tauranga
+          </h3>
+        </div>
+
         <div class="service-categories">
-          <div class="category-card">
-            <h3>Mental Health Care:</h3>
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-              <li>Item 3</li>
+          <div class="category-card group-card group-coming-soon">
+            <div class="event-details">
+              <p><strong>PLACEHOLDER</strong></p>
+              <p>PLACEHOLDER</p>
+              <ul>
+                <li>
+                  <i class="fa-solid fa-envelope" aria-hidden="true"></i>
+                  <span>PLACEHOLDER</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <!--Whakatane Groups -->
+        <div class="group-location-section">
+          <h3 class="group-location-heading">
+            <i class="fa-solid fa-location-dot" aria-hidden="true"></i>
+            Whakat&#257;ne
+          </h3>
+        </div>
+
+        <div class="service-categories">
+          <!-- Teen Group -->
+          <div class="category-card group-card">
+            <div class="group-card-header">
+              <h4 class="group-card-title">Teen Group</h4>
+              <span
+                class="js-upcoming-date group-next-badge"
+                data-rule="1-Tuesday"></span>
+            </div>
+            <p class="group-card-desc">
+              A dedicated space for gender-diverse rangatahi to connect and be
+              themselves.
+            </p>
+            <ul class="event-details-list">
+              <li>
+                <i class="fa-solid fa-calendar" aria-hidden="true"></i>
+                <span
+                  ><strong>Regular:</strong> First Tuesday of each month</span
+                >
+              </li>
+              <li>
+                <i class="fa-solid fa-calendar-days" aria-hidden="true"></i>
+                <span
+                  ><strong>School Holidays:</strong> Tuesdays during term breaks</span
+                >
+              </li>
+              <li>
+                <i class="fa-solid fa-clock" aria-hidden="true"></i>
+                <span><strong>Time:</strong> 5:00pm — 6:30pm</span>
+              </li>
+              <li>
+                <i class="fa-solid fa-location-dot" aria-hidden="true"></i>
+                <span><strong>Venue:</strong> Art House, Whakatāne</span>
+              </li>
             </ul>
           </div>
 
-          <div class="category-card">
-            <h3>Transition Support:</h3>
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-              <li>Item 3</li>
+          <!-- Adult Group -->
+          <div class="category-card group-card">
+            <div class="group-card-header">
+              <h4 class="group-card-title">Adult Group</h4>
+              <span
+                class="js-upcoming-date group-next-badge"
+                data-rule="1-Friday"></span>
+            </div>
+            <p class="group-card-desc">
+              A welcoming peer support group for gender-diverse adults.
+            </p>
+            <ul class="event-details-list">
+              <li>
+                <i class="fa-solid fa-calendar" aria-hidden="true"></i>
+                <span><strong>When:</strong> First Friday of each month</span>
+              </li>
+              <li>
+                <i class="fa-solid fa-clock" aria-hidden="true"></i>
+                <span><strong>Time:</strong> 6:00pm — 7:30pm</span>
+              </li>
+              <li>
+                <i class="fa-solid fa-location-dot" aria-hidden="true"></i>
+                <span><strong>Venue:</strong> Art House, Whakatāne</span>
+              </li>
             </ul>
           </div>
 
-          <div class="category-card">
-            <h3>Ongoing Care:</h3>
-            <ul>
-              <li>Item 1</li>
-              <li>Item 2</li>
-              <li>Item 3</li>
-            </ul>
+          <!--Online Adult Group -->
+          <div class="category-card group-card">
+            <div class="group-card-header">
+              <h4 class="group-card-title">Online Adult Group</h4>
+              <span
+                class="js-upcoming-date group-next-badge"
+                data-rule="L-Wednesday"></span>
+            </div>
+            <div class="event-details">
+              <p class="group-card-desc">
+                Join us from anywhere in Aotearoa — our online group is open to
+                all gender-diverse adults.
+              </p>
+              <ul class="event-details-list">
+                <li>
+                  <i class="fa-solid fa-calendar" aria-hidden="true"></i>
+                  <span
+                    ><strong>When:</strong> Last Wednesday of each month</span
+                  >
+                </li>
+                <li>
+                  <i class="fa-solid fa-clock" aria-hidden="true"></i>
+                  <span><strong>Time:</strong> 6:00pm — 7:30pm</span>
+                </li>
+                <li>
+                  <i class="fa-solid fa-laptop" aria-hidden="true"></i>
+                  <span><strong>Format:</strong> Online</span>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
@@ -307,7 +407,7 @@ import '../styles/services.css';
               <ul class="event-details-list">
                 <li>
                   <i class="fa-solid fa-calendar" aria-hidden="true"></i>
-                  <span><strong>Tuesdays:</strong> 4:00pm – 6:30PM</span>
+                  <span><strong>Tuesdays:</strong> 4:00pm – 6:30pm</span>
                 </li>
                 <li>
                   <i class="fa-solid fa-location-dot" aria-hidden="true"></i>
@@ -634,6 +734,7 @@ import '../styles/services.css';
 </BaseLayout>
 
 <script is:inline>
+  // Accordian Toggle Logic
   (function () {
     function toggleAccordion(header) {
       var content = header.nextElementSibling;
@@ -660,4 +761,62 @@ import '../styles/services.css';
       header.style.cursor = 'pointer';
     });
   })();
+
+  // Event Date Calculations
+  function initUpcomingDates() {
+    const dayNames = [
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+    ];
+
+    document.querySelectorAll('.js-upcoming-date').forEach((el) => {
+      const rule = el.dataset.rule;
+      if (!rule) return;
+
+      const [occurrence, dayName] = rule.split('-');
+      const targetDay = dayNames.indexOf(dayName);
+      const now = new Date();
+
+      let meetingDate = calculateMeeting(
+        now.getFullYear(),
+        now.getMonth(),
+        occurrence,
+        targetDay,
+      );
+
+      if (meetingDate < now.setHours(0, 0, 0, 0)) {
+        meetingDate = calculateMeeting(
+          now.getFullYear(),
+          now.getMonth() + 1,
+          occurrence,
+          targetDay,
+        );
+      }
+
+      el.textContent = `— Next: ${meetingDate.toLocaleDateString('en-NZ', { day: 'numeric', month: 'short' })}`;
+      el.style.fontWeight = 'bold';
+      el.style.visibility = 'visible';
+    });
+
+    function calculateMeeting(year, month, occ, dayIdx) {
+      if (occ === 'L') {
+        let d = new Date(year, month + 1, 0);
+        while (d.getDay() !== dayIdx) d.setDate(d.getDate() - 1);
+        return d;
+      } else {
+        let d = new Date(year, month, 1);
+        while (d.getDay() !== dayIdx) d.setDate(d.getDate() + 1);
+        d.setDate(d.getDate() + (parseInt(occ) - 1) * 7);
+        return d;
+      }
+    }
+  }
+
+  initUpcomingDates();
+  document.addEventListener('astro:after-swap', initUpcomingDates);
 </script>

--- a/src/styles/services.css
+++ b/src/styles/services.css
@@ -279,6 +279,83 @@
   font-size: 1.2rem;
 } */
 
+/* Group location sub-sections */
+.group-location-section {
+  margin-bottom: 2.5rem;
+}
+
+.group-location-section:last-child {
+  margin-bottom: 0;
+}
+
+.group-location-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: clamp(1.2rem, 2.5vw, 1.45rem);
+  font-weight: 600;
+  color: var(--purple);
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 2px solid rgba(173, 152, 196, 0.35);
+}
+
+.group-location-heading i {
+  color: var(--primary-lavender);
+  font-size: 1rem;
+}
+
+.group-coming-soon {
+  opacity: 0.75;
+  border-style: dashed;
+  margin-bottom: 20px;
+}
+/* Group Cards */
+.group-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.group-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.6rem;
+}
+
+.group-card-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--purple);
+  margin: 0;
+  line-height: 1.3;
+}
+
+.group-card-desc {
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--purple);
+  opacity: 0.8;
+  margin: 0 0 1rem 0;
+}
+
+.group-next-badge {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  flex-shrink: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: white;
+  background-color: var(--primary-lavender);
+  padding: 3px 10px;
+  border-radius: 50px;
+  line-height: 1.6;
+  visibility: hidden;
+}
+
 .event-details p {
   padding-bottom: 10px;
 }


### PR DESCRIPTION
This PR enhances the services page by introducing automated date calculations for recurring group sessions. This changes focuses on improving user experience by providing specific calendar dates for the next meeting.

## Key Changes

Automated "Next Meeting" Badges:
-  Implemented a JS utility that calculates the next meeting date based on recurring rules (e.g., "First Tuesday" or "Last Wednesday").
-  The script automatically handles month-rollovers (If the current month's meeting has passed it calculates the date for the following month

UX Improvement (Cognitive Load): Replaces the need for users to perform "Calendar math" visitors now see a specific date for their next session instead of just a rule.

Astro Compatibility:

- Used is:inline and astro:after-swap listeners to ensure scripts re-run correctly during client-side navigation
-  Applied visibility: hidden in CSS and revealed via JS to prevent layout shift while dates are being calculated

## Technical Working & Calculations
The calculation logic identifies the meeting date relative to the current day. For the "Last of the month" rules, it calculates the last day of the month and walks backward to the target day index.

Formula for Ordinal Dates (e.g., 1st Tuesday):

> Date=FirstDayOfMonth+(TargetDayIdx−FirstDayIdx+7)(mod7)+(Occurrence−1)×7

## Screenshots
<img width="1224" height="1048" alt="image" src="https://github.com/user-attachments/assets/6765fd44-e214-4d9b-a7cb-1b3fed74b8ae" />