### PR TITLE
hotfix: Save date of birth to referral spreadsheet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,22 @@ jobs:
           workingDirectory: dist/server
           wranglerVersion: '4'
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          secrets: |
-            TURNSTILE_SECRET_KEY
-            GOOGLE_SERVICE_ACCOUNT_EMAIL
-            GOOGLE_PRIVATE_KEY
-            GOOGLE_SPREADSHEET_ID
-        env:
-          TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
-          GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
-          GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
-          GOOGLE_SPREADSHEET_ID: ${{ secrets.GOOGLE_SPREADSHEET_ID }}
+          # TEMPORARY: secrets upload disabled for this deploy.
+          # The Worker's latest version != deployed version (Cloudflare error
+          # 10215), so any secret edit is refused and would block the deploy.
+          # A plain `wrangler deploy` re-aligns latest==deployed. Existing
+          # secrets persist untouched. RESTORE this block in the next PR once
+          # the version split is cleared.
+          # secrets: |
+          #   TURNSTILE_SECRET_KEY
+          #   GOOGLE_SERVICE_ACCOUNT_EMAIL
+          #   GOOGLE_PRIVATE_KEY
+          #   GOOGLE_SPREADSHEET_ID
+        # env:
+        #   TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY }}
+        #   GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+        #   GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
+        #   GOOGLE_SPREADSHEET_ID: ${{ secrets.GOOGLE_SPREADSHEET_ID }}
       - name: Upload preview version
         if: github.ref == 'refs/heads/preview'
         uses: cloudflare/wrangler-action@v3

--- a/src/tests/google-sheets.test.ts
+++ b/src/tests/google-sheets.test.ts
@@ -101,6 +101,7 @@ const referralFields = {
   suburb: 'CBD',
   'area-code': '1010',
   'referral-source': 'GP',
+  'date-of-birth': '15/06/1990',
 };
 
 const trainingFields = {
@@ -510,7 +511,7 @@ describe('appendFormSubmission — row building', () => {
   });
 
   describe('referral', () => {
-    it('builds the correct number of columns (16)', async () => {
+    it('builds the correct number of columns (17)', async () => {
       const fetchMock = vi.mocked(fetch);
       mockFullCycle(fetchMock, SHEET_HEADERS.referral);
       await appendFormSubmission('referral', referralFields);
@@ -533,12 +534,14 @@ describe('appendFormSubmission — row building', () => {
       // col: 0=Timestamp 1=Referral Type 2=First Name 3=Last Name 4=Email
       //      5=Phone 6=Address 7=City 8=Suburb 9=Area Code 10=Referral Source
       //      11=Identified Name 12=NHI 13=Out Status 14=Services 15=Additional Info
+      //      16=Date of Birth
       expect(row[1]).toBe('GP'); // Referral Type
       expect(row[2]).toBe('Bob'); // First Name
       expect(row[3]).toBe('Smith'); // Last Name
       expect(row[4]).toBe('bob@example.com'); // Email
       expect(row[5]).toBe('021000000'); // Phone
       expect(row[10]).toBe('GP'); // Referral Source
+      expect(row[16]).toBe('15/06/1990'); // Date of Birth
     });
 
     it('maps Identified Name, NHI, and Services correctly', async () => {

--- a/src/utils/google-sheets.ts
+++ b/src/utils/google-sheets.ts
@@ -51,6 +51,7 @@ export const SHEET_HEADERS: Record<FormType, string[]> = {
     'Out Status',
     'Services',
     'Additional Info',
+    'Date of Birth',
   ],
   training: [
     'Timestamp',
@@ -84,6 +85,7 @@ const FIELD_TO_HEADER: Record<string, string> = {
   'out-status': 'Out Status',
   services: 'Services',
   'additional-info': 'Additional Info',
+  'date-of-birth': 'Date of Birth',
   'contact-name': 'Contact Name',
   'contact-phone': 'Contact Phone',
   'training-hours': 'Training Hours',


### PR DESCRIPTION
## Problem
The referral form's **date of birth** is validated on submit but never reaches the spreadsheet. `SHEET_HEADERS.referral` and `FIELD_TO_HEADER` in `google-sheets.ts` had no Date of Birth entry, so `ensureSheet` never created the column and the value was dropped on append. The DoB commit (`a3edc05`) added the field to the form, action, and tests but never touched the Sheets mapping.

## Fix
- Add `'Date of Birth'` to `SHEET_HEADERS.referral` and `'date-of-birth' -> 'Date of Birth'` to `FIELD_TO_HEADER`.
- Header is **appended at the end** so existing rows stay aligned under their current columns (a mid-list insert would relabel historical data, since `ensureSheet` rewrites only the header row).
- Tests updated: DoB added to the referral fixture, column-count title `(16)->(17)`, and a `row[16]` mapping assertion. Full suite: 114 passing.

## ⚠️ Temporary deploy change (must be reverted next PR)
The production Worker is in a split state — **latest version != currently-deployed version** — so Cloudflare refuses any secret edit (error **10215**), which would block the deploy entirely. This PR **comments out the `secrets:`/`env:` block** in the `Deploy to production` step so the job runs a plain `wrangler deploy`, which re-aligns latest==deployed and ships the fix. Existing Worker secrets persist untouched.

**Follow-up required:** restore the commented `secrets:`/`env:` block once the split is cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)